### PR TITLE
Fix fetch URLs to use base path

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -931,7 +931,7 @@ const App = () => {
   useEffect(() => {
     const loadMessage = async () => {
       try {
-        const response = await fetch('/mensaje.json');
+        const response = await fetch(`${import.meta.env.BASE_URL}mensaje.json`);
         if (!response.ok) return;
         const data = await response.json();
         if (data.mensaje_portada) {
@@ -950,7 +950,7 @@ const App = () => {
       setLoading(true);
       try {
         // Cargar productos reales desde JSON
-        const response = await fetch('/productos.json');
+        const response = await fetch(`${import.meta.env.BASE_URL}productos.json`);
         const productosReales = await response.json();
 
         setProducts(productosReales);


### PR DESCRIPTION
## Summary
- access mensaje.json and productos.json relative to Vite base URL

## Testing
- `npm run dev` *(fails: vite not found)*
- `npm run build` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_686f38f9cd78832e8796279aadd4795c