### PR TITLE
Update service worker to cache mensaje.json

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,6 +1,6 @@
 // sw.js - Service Worker para MARÉ Catálogo PWA
 // Versión del cache - incrementar cuando haya cambios importantes
-const CACHE_VERSION = 'mare-v1.0.0';
+const CACHE_VERSION = 'mare-v1.0.1';
 const STATIC_CACHE = `${CACHE_VERSION}-static`;
 const DYNAMIC_CACHE = `${CACHE_VERSION}-dynamic`;
 const IMAGES_CACHE = `${CACHE_VERSION}-images`;
@@ -11,6 +11,7 @@ const STATIC_ASSETS = [
   '/index.html',
   '/manifest.json',
   '/productos.json',
+  '/mensaje.json',
   '/icon-192.png',
   '/icon-512.png'
 ];


### PR DESCRIPTION
## Summary
- include `mensaje.json` in the cached static assets
- bump cache version to `mare-v1.0.1`

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686f3a1ed154832e9c6235a0816afad3