### PR TITLE
Add PDF export option in cart modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "lucide-react": "^0.263.1",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "jspdf": "^2.5.1"
       },
       "devDependencies": {
         "@types/react": "^18.2.15",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "dependencies": {
     "lucide-react": "^0.263.1",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "jspdf": "^2.5.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.15",


### PR DESCRIPTION
## Summary
- include jsPDF as dependency
- generate PDF from cart items and optional WhatsApp share
- add actions in cart modal to download or send the PDF

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686f429f4558832e877dc0e66cdefb43