### PR TITLE
Store producto estado from Excel

### DIFF
--- a/convertir-completo.cjs
+++ b/convertir-completo.cjs
@@ -33,8 +33,8 @@ try {
     for (let i = 1; i < jsonData.length; i++) {
         const row = jsonData[i];
 
-        // Solo productos con código y estado visible
-        if (!row || !row[0] || row[19] !== 'visible') {
+        // Solo productos con código
+        if (!row || !row[0]) {
             continue;
         }
 
@@ -48,7 +48,7 @@ try {
                 categoria: String(row[3] || '').trim(),
                 medidas: String(row[4] || '').trim(),
                 precio: parseFloat(row[5]) || 0,
-                estado: 'visible',
+                estado: String(row[19] || '').trim(),
                 imagenes: [],
                 sinColor: row[17] === 'SI',
                 permitirSurtido: row[18] === 'SI',

--- a/convertir-excel.js
+++ b/convertir-excel.js
@@ -161,9 +161,9 @@ function convertirExcel() {
 
         for (let i = 1; i < jsonData.length; i++) {
             const row = jsonData[i];
-            
-            // Solo productos con código y estado visible
-            if (!row || !row[0] || row[19] !== 'visible') {
+
+            // Solo productos con código
+            if (!row || !row[0]) {
                 continue;
             }
 
@@ -175,7 +175,7 @@ function convertirExcel() {
                     categoria: String(row[3] || '').trim(),
                     medidas: String(row[4] || '').trim(),
                     precio: parseFloat(row[5]) || 0,
-                    estado: 'visible',
+                    estado: String(row[19] || '').trim(),
                     imagenes: [],
                     sinColor: row[17] === 'SI',
                     permitirSurtido: row[18] === 'SI',


### PR DESCRIPTION
## Summary
- keep products that aren't marked `visible`
- preserve the state text from the Excel file when exporting

## Testing
- `npm run build` *(fails: Cannot find module 'react')*
- `npm run convert` *(fails: Cannot find package 'xlsx')*

------
https://chatgpt.com/codex/tasks/task_e_686f47d1cff8832ebc8d9479aeb77bfa