### PR TITLE
Reduce header logo size

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1328,7 +1328,7 @@ const App = () => {
                 <img
                   src="/logo-mare.png"
                   alt="MARÉ logo"
-                  className="h-10 sm:h-14 w-auto"
+                  className="h-8 sm:h-10 w-auto"
                 />
                 <span className="text-xs" style={{ color: '#8F6A50' }}>
                   By Feraben SRL


### PR DESCRIPTION
## Summary
- resize MARÉ logo in header to avoid extra vertical space

## Testing
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_687133e28a08832ead9a873d6c118d57