### PR TITLE
Add Node type support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "postcss": "^8.4.24",
         "tailwindcss": "^3.3.0",
         "typescript": "^5.0.2",
+        "@types/node": "^20.4.2",
         "vite": "^4.4.5",
         "xlsx": "^0.18.5"
       }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "postcss": "^8.4.24",
     "tailwindcss": "^3.3.0",
     "typescript": "^5.0.2",
+    "@types/node": "^20.4.2",
     "vite": "^4.4.5",
     "xlsx": "^0.18.5"
   }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,9 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "types": ["vite/client", "node"]
   },
-  "include": ["src"],
+  "include": ["src", "vite-env.d.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## Summary
- install @types/node
- expose node and vite/client types
- generate `vite-env.d.ts`

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'node' or 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68713ca41a68832e875ad1ccda191a9a